### PR TITLE
[feat] 주문 생성 기능 구현

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -8,7 +8,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
     // 기본
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // 주문
+    QUANTITY_TOO_MANY(HttpStatus.BAD_REQUEST, "주문할 수 없는 수량입니다. 수량을 다시 확인해주세요."),
+
+    // 상품
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다. 다시 시도해주세요."),
+
+    // 가격
+    PRICE_NOT_FOUND(HttpStatus.NOT_FOUND, "가격 정보를 찾을 수 없습니다. 죄송합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/wanted/gold/exception/NotFoundException.java
+++ b/src/main/java/com/wanted/gold/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.wanted.gold.exception;
+
+public class NotFoundException extends BaseException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.wanted.gold.exception.handler;
 
 import com.wanted.gold.exception.BadRequestException;
 import com.wanted.gold.exception.ErrorResponse;
+import com.wanted.gold.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,6 +14,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
         return ResponseEntity.badRequest()
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 }

--- a/src/main/java/com/wanted/gold/order/controller/OrderController.java
+++ b/src/main/java/com/wanted/gold/order/controller/OrderController.java
@@ -1,0 +1,26 @@
+package com.wanted.gold.order.controller;
+
+import com.wanted.gold.order.dto.CreateOrderRequestDto;
+import com.wanted.gold.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+
+    // 주문 생성
+    @PostMapping("")
+    public ResponseEntity<String> createOrder(@Valid @RequestBody CreateOrderRequestDto requestDto) {
+        String response = orderService.createOrder(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/wanted/gold/order/domain/Delivery.java
+++ b/src/main/java/com/wanted/gold/order/domain/Delivery.java
@@ -1,16 +1,14 @@
 package com.wanted.gold.order.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "deliveries")

--- a/src/main/java/com/wanted/gold/order/domain/Order.java
+++ b/src/main/java/com/wanted/gold/order/domain/Order.java
@@ -4,8 +4,6 @@ import com.wanted.gold.product.domain.Product;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -38,10 +36,8 @@ public class Order {
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal quantity;
 
-    @CreatedDate
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     private UUID userId;

--- a/src/main/java/com/wanted/gold/order/domain/Order.java
+++ b/src/main/java/com/wanted/gold/order/domain/Order.java
@@ -2,10 +2,7 @@ package com.wanted.gold.order.domain;
 
 import com.wanted.gold.product.domain.Product;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,6 +13,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "orders")

--- a/src/main/java/com/wanted/gold/order/domain/Payment.java
+++ b/src/main/java/com/wanted/gold/order/domain/Payment.java
@@ -1,16 +1,14 @@
 package com.wanted.gold.order.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "payments")

--- a/src/main/java/com/wanted/gold/order/dto/CreateOrderRequestDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/CreateOrderRequestDto.java
@@ -3,13 +3,14 @@ package com.wanted.gold.order.dto;
 import com.wanted.gold.order.domain.OrderType;
 import com.wanted.gold.product.domain.GoldType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
 public record CreateOrderRequestDto(
-        @NotBlank OrderType orderType,
-        @NotBlank BigDecimal quantity,
-        @NotBlank GoldType goldType,
+        @NotNull OrderType orderType,
+        @NotNull BigDecimal quantity,
+        @NotNull GoldType goldType,
         @NotBlank String address,
         @NotBlank String recipientName,
         @NotBlank String recipientPhone,

--- a/src/main/java/com/wanted/gold/order/dto/CreateOrderRequestDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/CreateOrderRequestDto.java
@@ -1,0 +1,19 @@
+package com.wanted.gold.order.dto;
+
+import com.wanted.gold.order.domain.OrderType;
+import com.wanted.gold.product.domain.GoldType;
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+public record CreateOrderRequestDto(
+        @NotBlank OrderType orderType,
+        @NotBlank BigDecimal quantity,
+        @NotBlank GoldType goldType,
+        @NotBlank String address,
+        @NotBlank String recipientName,
+        @NotBlank String recipientPhone,
+        @NotBlank String bankName,
+        @NotBlank String bankAccount
+) {
+}

--- a/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.gold.order.repository;
+
+import com.wanted.gold.order.domain.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+}

--- a/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.gold.order.repository;
+
+import com.wanted.gold.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.gold.order.repository;
+
+import com.wanted.gold.order.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/wanted/gold/order/service/OrderService.java
+++ b/src/main/java/com/wanted/gold/order/service/OrderService.java
@@ -1,4 +1,84 @@
 package com.wanted.gold.order.service;
 
+import com.wanted.gold.exception.BadRequestException;
+import com.wanted.gold.exception.ErrorCode;
+import com.wanted.gold.exception.NotFoundException;
+import com.wanted.gold.order.domain.Delivery;
+import com.wanted.gold.order.domain.Order;
+import com.wanted.gold.order.domain.OrderType;
+import com.wanted.gold.order.domain.Payment;
+import com.wanted.gold.order.dto.CreateOrderRequestDto;
+import com.wanted.gold.order.repository.DeliveryRepository;
+import com.wanted.gold.order.repository.OrderRepository;
+import com.wanted.gold.order.repository.PaymentRepository;
+import com.wanted.gold.product.domain.Price;
+import com.wanted.gold.product.domain.Product;
+import com.wanted.gold.product.repository.PriceRepository;
+import com.wanted.gold.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
 public class OrderService {
+    private final DeliveryRepository deliveryRepository;
+    private final OrderRepository orderRepository;
+    private final PriceRepository priceRepository;
+    private final ProductRepository productRepository;
+    private final PaymentRepository paymentRepository;
+
+    // 주문 생성
+    public String createOrder(CreateOrderRequestDto requestDto) {
+        // 입력받은 금 종류로 product 찾기
+        Product product = productRepository.findByGoldType(requestDto.goldType())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+        // OrderType = PURCHASE(구매)의 경우 주문 수량이 재고보다 클 경우 error
+        if(requestDto.orderType() == OrderType.PURCHASE && (requestDto.quantity().compareTo(product.getStock()) > 0))
+            throw new BadRequestException(ErrorCode.QUANTITY_TOO_MANY);
+        // OrderType = PURCHASE(구매)의 경우 주문 수량이 재고보다 같거나 작을 경우 상품 재고 차감
+        if(requestDto.orderType() == OrderType.PURCHASE) {
+            product.deductProductStock(requestDto.quantity());
+        }
+        // product와 주문 유형으로 product 가격 찾기 - 가장 최근에 등록된 값
+        Price price = priceRepository.findTopByOrderTypeAndProduct_ProductIdOrderByCreatedAtDesc(requestDto.orderType(), product.getProductId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PRICE_NOT_FOUND));
+        // Price의 그램 당 가격과 입력받은 수량으로 총 주문가격 계산
+        Long totalPrice = calculateTotalPrice(requestDto.quantity(), price.getPricePerGram());
+        // 주문 생성
+        Order order = Order.builder()
+                .orderType(requestDto.orderType())
+                .totalPrice(totalPrice)
+                .quantity(requestDto.quantity())
+                .product(product)
+                .build();
+        orderRepository.save(order);
+        // 배송 생성
+        Delivery delivery = Delivery.builder()
+                .address(requestDto.address())
+                .recipientName(requestDto.recipientName())
+                .recipientPhone(requestDto.recipientPhone())
+                .order(order)
+                .build();
+        deliveryRepository.save(delivery);
+        // 결제 생성
+        Payment payment = Payment.builder()
+                .paymentAmount(totalPrice)
+                .bankName(requestDto.bankName())
+                .bankAccount(requestDto.bankAccount())
+                .order(order)
+                .build();
+        paymentRepository.save(payment);
+        // 주문 성공 메시지 반환
+        return "주문에 성공했습니다.";
+    }
+
+    // 수량과 그램 당 가격으로 총 주문 가격 계산
+    public Long calculateTotalPrice(BigDecimal quantity, Long pricePerGram) {
+        BigDecimal priceDecimal = BigDecimal.valueOf(pricePerGram);
+        BigDecimal totalPriceDecimal = quantity.multiply(priceDecimal);
+        // 소수점 아래 버리고 Long 타입으로 변환
+        return totalPriceDecimal.longValue();
+    }
 }

--- a/src/main/java/com/wanted/gold/order/service/OrderService.java
+++ b/src/main/java/com/wanted/gold/order/service/OrderService.java
@@ -3,10 +3,7 @@ package com.wanted.gold.order.service;
 import com.wanted.gold.exception.BadRequestException;
 import com.wanted.gold.exception.ErrorCode;
 import com.wanted.gold.exception.NotFoundException;
-import com.wanted.gold.order.domain.Delivery;
-import com.wanted.gold.order.domain.Order;
-import com.wanted.gold.order.domain.OrderType;
-import com.wanted.gold.order.domain.Payment;
+import com.wanted.gold.order.domain.*;
 import com.wanted.gold.order.dto.CreateOrderRequestDto;
 import com.wanted.gold.order.repository.DeliveryRepository;
 import com.wanted.gold.order.repository.OrderRepository;
@@ -19,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -49,13 +47,16 @@ public class OrderService {
         // 주문 생성
         Order order = Order.builder()
                 .orderType(requestDto.orderType())
+                .orderStatus(OrderStatus.ORDER_COMPLETED)
                 .totalPrice(totalPrice)
                 .quantity(requestDto.quantity())
+                .createdAt(LocalDateTime.now())
                 .product(product)
                 .build();
         orderRepository.save(order);
         // 배송 생성
         Delivery delivery = Delivery.builder()
+                .deliveryStatus(DeliveryStatus.PENDING)
                 .address(requestDto.address())
                 .recipientName(requestDto.recipientName())
                 .recipientPhone(requestDto.recipientPhone())
@@ -64,6 +65,7 @@ public class OrderService {
         deliveryRepository.save(delivery);
         // 결제 생성
         Payment payment = Payment.builder()
+                .paymentStatus(PaymentStatus.PENDING)
                 .paymentAmount(totalPrice)
                 .bankName(requestDto.bankName())
                 .bankAccount(requestDto.bankAccount())

--- a/src/main/java/com/wanted/gold/order/service/OrderService.java
+++ b/src/main/java/com/wanted/gold/order/service/OrderService.java
@@ -1,0 +1,4 @@
+package com.wanted.gold.order.service;
+
+public class OrderService {
+}

--- a/src/main/java/com/wanted/gold/product/domain/Price.java
+++ b/src/main/java/com/wanted/gold/product/domain/Price.java
@@ -1,5 +1,6 @@
 package com.wanted.gold.product.domain;
 
+import com.wanted.gold.order.domain.OrderType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,7 @@ public class Price {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PriceType priceType;
+    private OrderType orderType;
 
     @Column(nullable = false)
     private Long pricePerGram;

--- a/src/main/java/com/wanted/gold/product/domain/Product.java
+++ b/src/main/java/com/wanted/gold/product/domain/Product.java
@@ -25,4 +25,9 @@ public class Product {
 
     @Column(nullable = false, precision = 10, scale = 2)
     private BigDecimal stock;
+
+    public Product deductProductStock(BigDecimal quantity) {
+        this.stock = this.stock.subtract(quantity);
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/product/repository/PriceRepository.java
+++ b/src/main/java/com/wanted/gold/product/repository/PriceRepository.java
@@ -1,0 +1,11 @@
+package com.wanted.gold.product.repository;
+
+import com.wanted.gold.order.domain.OrderType;
+import com.wanted.gold.product.domain.Price;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PriceRepository extends JpaRepository<Price, Long> {
+    Optional<Price> findTopByOrderTypeAndProduct_ProductIdOrderByCreatedAtDesc(OrderType orderType, Long productId);
+}

--- a/src/main/java/com/wanted/gold/product/repository/ProductRepository.java
+++ b/src/main/java/com/wanted/gold/product/repository/ProductRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.gold.product.repository;
+
+import com.wanted.gold.product.domain.GoldType;
+import com.wanted.gold.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    // 금 종류로 product 찾기
+    Optional<Product> findByGoldType(GoldType goldType);
+}


### PR DESCRIPTION
## Issue
- #5 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/create_order -> dev

## 변경 사항
- 주문 생성에 필요한 requestDto 작성
- 구매 주문의 경우 주문 수량이 재고보다 큰 경우 에러 처리
- 구매 주문의 경우 주문 수량이 재고보다 작은 경우 상품 재고 차감
- 주문 총 금액의 경우 주문 유형과 상품 품목으로 가격을 찾아 그 중 가장 최근에 입력된 금액으로 계산
- 주문 생성하면서 배송과 결제 객체도 생성
- 주문, 배송, 결제 상태 자동 생성 추가

## 테스트 결과
- 상품의 경우 99.9% 금 10000g과 99.99% 금 10300.55g이 있음
- 가격의 경우 99.9% 금의 가장 최근 구매 가격은 그램 당 130

### Request
```java
HTTP : POST
URL: /api/orders
```
- Request Body
(
```
{
    "orderType": "PURCHASE",
    "quantity" : 20.5,
    "goldType" : "GOLD_999",
    "address" : "서울시 영등포구 여의대방로",
    "recipientName" : "이지원",
    "recipientPhone" : "01011112222",
    "bankName" : "허브은행",
    "bankAccount" : "111-22-333333"
}
```

### Response : 성공시
`201 Created`
```
주문에 성공했습니다.
```

### Response : 실패시
- 구매 주문 시 주문수량이 재고보다 클 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "주문할 수 없는 수량입니다. 수량을 다시 확인해주세요."
}
```

- 하나라도 빈 값을 입력했을 경우
`400 Bad Request`