### PR TITLE
[feat] 주문 전체 목록 조회

### DIFF
--- a/src/main/java/com/wanted/gold/order/controller/OrderController.java
+++ b/src/main/java/com/wanted/gold/order/controller/OrderController.java
@@ -1,15 +1,19 @@
 package com.wanted.gold.order.controller;
 
+import com.wanted.gold.order.domain.Order;
+import com.wanted.gold.order.domain.OrderType;
 import com.wanted.gold.order.dto.CreateOrderRequestDto;
+import com.wanted.gold.order.dto.OrderListPaginationResponseDto;
+import com.wanted.gold.order.dto.OrderListResponseDto;
 import com.wanted.gold.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -22,5 +26,18 @@ public class OrderController {
     public ResponseEntity<String> createOrder(@Valid @RequestBody CreateOrderRequestDto requestDto) {
         String response = orderService.createOrder(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 주문 전체 목록 조회
+    @GetMapping("")
+    public ResponseEntity<OrderListPaginationResponseDto<OrderListResponseDto>> orderList(@RequestParam(required = true) LocalDate date,
+                                                                                          @RequestParam(required = true) OrderType type,
+                                                                                          @RequestParam(defaultValue = "0") int offset,
+                                                                                          @RequestParam(defaultValue = "10") int limit) {
+        OrderListPaginationResponseDto<OrderListResponseDto> orderPage = orderService.getOrders(date, type, offset, limit);
+        // 주문이 하나도 없을 경우
+        if(orderPage.data().size() == 0)
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return ResponseEntity.ok().body(orderPage);
     }
 }

--- a/src/main/java/com/wanted/gold/order/dto/OrderListPaginationResponseDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/OrderListPaginationResponseDto.java
@@ -1,0 +1,12 @@
+package com.wanted.gold.order.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record OrderListPaginationResponseDto<T>(
+        boolean success,
+        String message,
+        List<T> data,
+        Map<String, String> links
+) {
+}

--- a/src/main/java/com/wanted/gold/order/dto/OrderListResponseDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/OrderListResponseDto.java
@@ -1,0 +1,16 @@
+package com.wanted.gold.order.dto;
+
+import com.wanted.gold.order.domain.OrderStatus;
+import com.wanted.gold.product.domain.GoldType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderListResponseDto(
+        OrderStatus orderStatus,
+        Long totalPrice,
+        BigDecimal quantity,
+        LocalDateTime updatedAt,
+        GoldType goldType
+) {
+}

--- a/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
@@ -1,7 +1,18 @@
 package com.wanted.gold.order.repository;
 
 import com.wanted.gold.order.domain.Order;
+import com.wanted.gold.order.domain.OrderType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    @Query("SELECT o FROM Order o WHERE DATE(o.createdAt) = :date AND o.orderType = :type")
+    Page<Order> findByCreatedAtDateAndAndOrderType(@Param("date") LocalDate date,
+                                                   @Param("type") OrderType type,
+                                                   Pageable pageable);
 }


### PR DESCRIPTION
## Issue
- #7 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/order_list -> dev

## 변경 사항
- 페이지네이션을 위한 ResponseDto 생성
- 입력한 날짜와 주문 유형이 일치하는 주문 데이터 pagination으로 반환
- 현재 페이지 기본값은 0, 현재 페이지 조회 개수 기본값은 10
- 페이지 링크는 이전 페이지와 다음 페이지 반환

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/orders?date=2024-09-07&type=PURCHASE&offset=0&limit=1
```
| Key | Description |
|-----|--------------|
| date | 조회할 날짜 |
| type | 주문 유형 |
| offset | 현재 페이지 번호 (기본값 0) |
| limit | 페이지 당 주문 조회 개수 (기본값 10) |

### Response : 성공시
`200 OK`
```
{
    "success": true,
    "message": "Success to search orders",
    "data": [
        {
            "orderStatus": "ORDER_COMPLETED",
            "totalPrice": 2665,
            "quantity": 20.50,
            "updatedAt": null,
            "goldType": "GOLD_999"
        }
    ],
    "links": {
        "next": "/orders?date=2024-09-07&type=PURCHASE&offset=1&limit=1"
    }
}
```

### Response : 실패시
- 잘못된 날짜 형식 또는 주문 유형을 입력했을 때
`400 Bad Request`