### PR TITLE
[feat] 주문 상세 조회

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -12,6 +12,13 @@ public enum ErrorCode {
 
     // 주문
     QUANTITY_TOO_MANY(HttpStatus.BAD_REQUEST, "주문할 수 없는 수량입니다. 수량을 다시 확인해주세요."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다. 다시 시도해주세요."),
+
+    // 배송
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
+
+    // 결제
+    PAYMENT_NOT_FOUNT(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다. 다시 시도해주세요."),

--- a/src/main/java/com/wanted/gold/order/controller/OrderController.java
+++ b/src/main/java/com/wanted/gold/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.wanted.gold.order.controller;
 import com.wanted.gold.order.domain.Order;
 import com.wanted.gold.order.domain.OrderType;
 import com.wanted.gold.order.dto.CreateOrderRequestDto;
+import com.wanted.gold.order.dto.OrderDetailResponseDto;
 import com.wanted.gold.order.dto.OrderListPaginationResponseDto;
 import com.wanted.gold.order.dto.OrderListResponseDto;
 import com.wanted.gold.order.service.OrderService;
@@ -39,5 +40,12 @@ public class OrderController {
         if(orderPage.data().size() == 0)
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         return ResponseEntity.ok().body(orderPage);
+    }
+
+    // 주문 상세 조회
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderDetailResponseDto> getOrder(@PathVariable Long orderId) {
+        OrderDetailResponseDto responseDto = orderService.getOrder(orderId);
+        return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/wanted/gold/order/dto/DeliveryResponseDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/DeliveryResponseDto.java
@@ -1,0 +1,14 @@
+package com.wanted.gold.order.dto;
+
+import com.wanted.gold.order.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record DeliveryResponseDto(
+        DeliveryStatus deliveryStatus,
+        LocalDateTime deliveryAt,
+        String address,
+        String recipientName,
+        String recipientPhone
+) {
+}

--- a/src/main/java/com/wanted/gold/order/dto/OrderDetailResponseDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/OrderDetailResponseDto.java
@@ -1,0 +1,21 @@
+package com.wanted.gold.order.dto;
+
+import com.wanted.gold.order.domain.OrderStatus;
+import com.wanted.gold.order.domain.OrderType;
+import com.wanted.gold.product.domain.GoldType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderDetailResponseDto(
+        OrderType orderType,
+        OrderStatus orderStatus,
+        Long totalPrice,
+        BigDecimal quantity,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        GoldType goldType,
+        DeliveryResponseDto deliveryResponseDto,
+        PaymentResponseDto paymentResponseDto
+) {
+}

--- a/src/main/java/com/wanted/gold/order/dto/PaymentResponseDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/PaymentResponseDto.java
@@ -1,0 +1,14 @@
+package com.wanted.gold.order.dto;
+
+import com.wanted.gold.order.domain.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public record PaymentResponseDto(
+        PaymentStatus paymentStatus,
+        LocalDateTime paymentAt,
+        Long paymentAmount,
+        String bankName,
+        String bankAccount
+) {
+}

--- a/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
@@ -3,5 +3,9 @@ package com.wanted.gold.order.repository;
 import com.wanted.gold.order.domain.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+    // 주문 식별번호로 주문에 해당하는 배송 찾기 - 해당하는 배송 여러개일 경우 deliveryId 큰 것
+    Optional<Delivery> findTopByOrder_OrderIdOrderByDeliveryIdDesc(Long orderId);
 }

--- a/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/OrderRepository.java
@@ -9,10 +9,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    // 날짜와 주문 유형으로 페이지네이션 활용해 주문 조회
     @Query("SELECT o FROM Order o WHERE DATE(o.createdAt) = :date AND o.orderType = :type")
     Page<Order> findByCreatedAtDateAndAndOrderType(@Param("date") LocalDate date,
                                                    @Param("type") OrderType type,
                                                    Pageable pageable);
+
+    // 주문 식별번호로 해당하는 주문 조회
+    Optional<Order> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
@@ -3,5 +3,9 @@ package com.wanted.gold.order.repository;
 import com.wanted.gold.order.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    // 주문 식별번호로 주문에 해당하는 결제 찾기 - 해당하는 결제 여러개일 경우 paymentId 큰 것
+    Optional<Payment> findTopByOrder_OrderIdOrderByPaymentIdDesc(Long orderId);
 }


### PR DESCRIPTION
## Issue
- #9 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/order_detail -> dev

## 변경 사항
- 주문 상세 조회에 필요한 ResponseDto 작성
    - 주문 조회 시 해당하는 배송 정보와 결제 정보도 같이 조회하기 위해 ResponseDto 작성
- 조회 시 상품 품목도 같이 출력
 
## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/orders/:orderId
```

### Response : 성공시
`200 OK`
```
{
    "orderType": "PURCHASE",
    "orderStatus": "ORDER_COMPLETED",
    "totalPrice": 2665,
    "quantity": 20.50,
    "createdAt": "2024-09-07T16:14:43.120932",
    "updatedAt": null,
    "goldType": "GOLD_999",
    "deliveryResponseDto": {
        "deliveryStatus": "PENDING",
        "deliveryAt": null,
        "address": "서울시 영등포구 여의대방로",
        "recipientName": "이지원",
        "recipientPhone": "01011112222"
    },
    "paymentResponseDto": {
        "paymentStatus": "PENDING",
        "paymentAt": null,
        "paymentAmount": 2665,
        "bankName": "허브은행",
        "bankAccount": "111-22-333333"
    }
}
```

### Response : 실패시
- 잘못된 `orderId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "주문을 찾을 수 없습니다. 다시 시도해주세요."
}
```