### PR TITLE
[feat] 주문삭제 기능

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     // 주문
     QUANTITY_TOO_MANY(HttpStatus.BAD_REQUEST, "주문할 수 없는 수량입니다. 수량을 다시 확인해주세요."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다. 다시 시도해주세요."),
+    ORDER_DELETE_FAILED(HttpStatus.BAD_REQUEST, "주문을 삭제할 수 없습니다."),
 
     // 배송
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/wanted/gold/order/controller/OrderController.java
+++ b/src/main/java/com/wanted/gold/order/controller/OrderController.java
@@ -48,4 +48,11 @@ public class OrderController {
         OrderDetailResponseDto responseDto = orderService.getOrder(orderId);
         return ResponseEntity.ok().body(responseDto);
     }
+
+    // 주문 삭제
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<Void> deleteOrder(@PathVariable Long orderId) {
+        orderService.deleteOrder(orderId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.gold.order.repository;
 
 import com.wanted.gold.order.domain.Delivery;
+import com.wanted.gold.order.domain.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,7 @@ import java.util.Optional;
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     // 주문 식별번호로 주문에 해당하는 배송 찾기 - 해당하는 배송 여러개일 경우 deliveryId 큰 것
     Optional<Delivery> findTopByOrder_OrderIdOrderByDeliveryIdDesc(Long orderId);
+
+    // 주문에 해당하는 배송 정보 삭제
+    void deleteAllByOrder(Order order);
 }

--- a/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.gold.order.repository;
 
+import com.wanted.gold.order.domain.Order;
 import com.wanted.gold.order.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,7 @@ import java.util.Optional;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // 주문 식별번호로 주문에 해당하는 결제 찾기 - 해당하는 결제 여러개일 경우 paymentId 큰 것
     Optional<Payment> findTopByOrder_OrderIdOrderByPaymentIdDesc(Long orderId);
+
+    // 주문에 해당하는 결제 정보 삭제
+    void deleteAllByOrder(Order order);
 }

--- a/src/main/java/com/wanted/gold/product/domain/Product.java
+++ b/src/main/java/com/wanted/gold/product/domain/Product.java
@@ -30,4 +30,9 @@ public class Product {
         this.stock = this.stock.subtract(quantity);
         return this;
     }
+
+    public Product increaseProductStock(BigDecimal quantity) {
+        this.stock = this.stock.add(quantity);
+        return this;
+    }
 }


### PR DESCRIPTION
## Issue
- #11 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/order_delete -> dev

## 변경 사항
- 주문 상태가 입금 또는 송금 완료된 상태일 경우 삭제 불가능
- 구매 주문의 경우 주문 생성 시 상품 재고를 차감했었기 때문에 주문 완료만 한 상태이고 구매 주문인 경우 상품 재고 다시 증가
- 주문과 연관된 배송, 결제 정보 먼저 삭제

## 테스트 결과

### Request
```java
HTTP : DELETE
URL: /api/orders/:orderId
```

### Response : 성공시
`204 No Content`

### Response : 실패시
- 주문 싱태가 입금 또는 송금이 완료된 상태일 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "주문을 삭제할 수 없습니다."
}
```

- 잘못된 orderId를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "주문을 찾을 수 없습니다. 다시 시도해주세요."
}
```