### PR TITLE
[feat] 결제 상태 수정

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ConflictException.java
+++ b/src/main/java/com/wanted/gold/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package com.wanted.gold.exception;
+
+public class ConflictException extends BaseException {
+
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConflictException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
 
     // 결제
-    PAYMENT_NOT_FOUNT(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_FAILED(HttpStatus.CONFLICT, "결제를 진행할 수 없습니다. 다시 시도해주세요."),
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다. 다시 시도해주세요."),

--- a/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.wanted.gold.exception.handler;
 
 import com.wanted.gold.exception.BadRequestException;
+import com.wanted.gold.exception.ConflictException;
 import com.wanted.gold.exception.ErrorResponse;
 import com.wanted.gold.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 }

--- a/src/main/java/com/wanted/gold/order/controller/PaymentController.java
+++ b/src/main/java/com/wanted/gold/order/controller/PaymentController.java
@@ -1,0 +1,24 @@
+package com.wanted.gold.order.controller;
+
+import com.wanted.gold.order.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    // 결제 상태 수정 - 입금 완료 또는 송금 완료
+    @PatchMapping("/{paymentId}/complete")
+    public ResponseEntity<String> updatePaymentStatus(@PathVariable Long paymentId) {
+        String response = paymentService.completePayment(paymentId);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/wanted/gold/order/controller/PaymentController.java
+++ b/src/main/java/com/wanted/gold/order/controller/PaymentController.java
@@ -2,7 +2,6 @@ package com.wanted.gold.order.controller;
 
 import com.wanted.gold.order.service.PaymentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/wanted/gold/order/domain/Order.java
+++ b/src/main/java/com/wanted/gold/order/domain/Order.java
@@ -45,4 +45,10 @@ public class Order {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
+
+    public Order updateOrderStatusAndTime(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+        this.updatedAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/order/domain/Payment.java
+++ b/src/main/java/com/wanted/gold/order/domain/Payment.java
@@ -37,4 +37,10 @@ public class Payment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
+
+    public Payment updatePaymentStatusAndTime(PaymentStatus paymentStatus) {
+        this.paymentStatus = paymentStatus;
+        this.paymentAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/PaymentRepository.java
@@ -12,4 +12,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // 주문에 해당하는 결제 정보 삭제
     void deleteAllByOrder(Order order);
+
+    // 결제 식별번호로 결제 찾기
+    Optional<Payment> findByPaymentId(Long paymentId);
 }

--- a/src/main/java/com/wanted/gold/order/service/OrderService.java
+++ b/src/main/java/com/wanted/gold/order/service/OrderService.java
@@ -151,7 +151,7 @@ public class OrderService {
         );
         // 주문 식별번호로 Payment 객체 찾기
         Payment payment = paymentRepository.findTopByOrder_OrderIdOrderByPaymentIdDesc(orderId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.PAYMENT_NOT_FOUNT));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
         // Payment -> PaymentResponseDto로 변환
         PaymentResponseDto paymentResponseDto = new PaymentResponseDto(
                 payment.getPaymentStatus(),

--- a/src/main/java/com/wanted/gold/order/service/PaymentService.java
+++ b/src/main/java/com/wanted/gold/order/service/PaymentService.java
@@ -1,0 +1,48 @@
+package com.wanted.gold.order.service;
+
+import com.wanted.gold.exception.ConflictException;
+import com.wanted.gold.exception.ErrorCode;
+import com.wanted.gold.exception.NotFoundException;
+import com.wanted.gold.order.domain.*;
+import com.wanted.gold.order.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public String completePayment(Long paymentId) {
+        // 출력 메시지
+        String message;
+        // 결제 식별번호로 payment 객체 찾기
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
+        // 결제와 연관된 order 객체
+        Order order = payment.getOrder();
+        // 주문 유형이 구매고 주문 상태가 주문 완료일 때
+        if(order.getOrderType() == OrderType.PURCHASE && order.getOrderStatus() == OrderStatus.ORDER_COMPLETED) {
+            // 결제 상태 입금 완료로 변경
+            payment.updatePaymentStatusAndTime(PaymentStatus.PAYMENT_COMPLETED);
+            // 주문 상태 입금 완료로 변경
+            order.updateOrderStatusAndTime(OrderStatus.PAYMENT_COMPLETED);
+            // 출력 메시지 수정
+            message = "입금이 완료됐습니다.";
+            // 주문 유형이 판매고 주문 상태가 주문 완료일 때
+        } else if(order.getOrderType() == OrderType.SALE && order.getOrderStatus() == OrderStatus.ORDER_COMPLETED) {
+            // 결제 상태 송금 완료로 변경
+            payment.updatePaymentStatusAndTime(PaymentStatus.PAYMENT_SENT);
+            // 주문 상태 송금 완료로 변경
+            order.updateOrderStatusAndTime(OrderStatus.PAYMENT_SENT);
+            // 출력 메시지 수정
+            message = "송금이 완료됐습니다.";
+            // 이외의 상황에서는 상태 변경 불가
+        } else {
+            throw new ConflictException(ErrorCode.PAYMENT_FAILED);
+        }
+        return message;
+    }
+}


### PR DESCRIPTION
## Issue
- #13 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/update_payment_status -> dev

## 변경 사항
- 주문 상태가 주문 완료일 때, 결제 상태를 완료로 업데이트
- 이미 결제가 완료됐거나 결제 완료를 진행할 수 없는 상황이라면 409 상태 코드 출력
- 결제 상태 업데이트와 함께 주문 상태도 업데이트

## 테스트 결과

### Request
```java
HTTP : PATCH
URL: /api/payments/:paymentId/complete
```

### Response : 성공시
`200 OK`
```
송금이 완료됐습니다.
```

### Response : 실패시
- 잘못된 `paymentId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "결제 정보를 찾을 수 없습니다."
}
```

- 이미 입금 또는 송금이 완료된 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "결제를 진행할 수 없습니다. 다시 시도해주세요."
}
```