### PR TITLE
[feat] 배송 상태 수정

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // 배송
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
+    DELIVERY_FAILED(HttpStatus.CONFLICT, "배송을 진행할 수 없습니다. 다시 시도해주세요."),
 
     // 결제
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/wanted/gold/order/controller/DeliveryController.java
+++ b/src/main/java/com/wanted/gold/order/controller/DeliveryController.java
@@ -1,6 +1,6 @@
 package com.wanted.gold.order.controller;
 
-import com.wanted.gold.order.service.PaymentService;
+import com.wanted.gold.order.service.DeliveryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -9,15 +9,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/payments")
+@RequestMapping("/api/deliveries")
 @RequiredArgsConstructor
-public class PaymentController {
-    private final PaymentService paymentService;
+public class DeliveryController {
+    private final DeliveryService deliveryService;
 
-    // 결제 상태 수정 - 입금 완료 또는 송금 완료
-    @PatchMapping("/{paymentId}/complete")
-    public ResponseEntity<String> completePayment(@PathVariable Long paymentId) {
-        String response = paymentService.completePayment(paymentId);
+    // 배송 상태 수정 - 발송 완료 또는 수령 완료
+    @PatchMapping("/{deliveryId}/complete")
+    public ResponseEntity<String> completeDelivery(@PathVariable Long deliveryId) {
+        String response = deliveryService.completeDelivery(deliveryId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/wanted/gold/order/domain/Delivery.java
+++ b/src/main/java/com/wanted/gold/order/domain/Delivery.java
@@ -37,4 +37,10 @@ public class Delivery {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
+
+    public Delivery updateDeliveryStatusAndTime(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+        this.deliveryAt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/wanted/gold/order/repository/DeliveryRepository.java
@@ -12,4 +12,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     // 주문에 해당하는 배송 정보 삭제
     void deleteAllByOrder(Order order);
+
+    // 배송 식별번호로 배송 찾기
+    Optional<Delivery> findByDeliveryId(Long deliveryId);
 }

--- a/src/main/java/com/wanted/gold/order/service/DeliveryService.java
+++ b/src/main/java/com/wanted/gold/order/service/DeliveryService.java
@@ -1,0 +1,53 @@
+package com.wanted.gold.order.service;
+
+import com.wanted.gold.exception.ConflictException;
+import com.wanted.gold.exception.ErrorCode;
+import com.wanted.gold.exception.NotFoundException;
+import com.wanted.gold.order.domain.*;
+import com.wanted.gold.order.repository.DeliveryRepository;
+import com.wanted.gold.product.domain.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+    private final DeliveryRepository deliveryRepository;
+
+    @Transactional
+    public String completeDelivery(Long deliveryId) {
+        // 출력 메시지
+        String message;
+        // 배송 식별번호로 delivery 객체 찾기
+        Delivery delivery = deliveryRepository.findByDeliveryId(deliveryId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DELIVERY_NOT_FOUND));
+        // 배송과 연관된 order 객체
+        Order order = delivery.getOrder();
+        // 주문 유형이 구매고 주문 상태가 입금 완료일 때
+        if(order.getOrderType() == OrderType.PURCHASE && order.getOrderStatus() == OrderStatus.PAYMENT_COMPLETED) {
+            // 배송 상태 발송 완료로 변경
+            delivery.updateDeliveryStatusAndTime(DeliveryStatus.SHIPPED);
+            // 주문 상태 발송 완료로 변경
+            order.updateOrderStatusAndTime(OrderStatus.SHIPPED);
+            // 출력 메시지 수정
+            message = "발송 완료. 이용해주셔서 감사합니다.";
+            // 주문 유형이 판매고 주문 상태가 송금 완료일 때
+        } else if(order.getOrderType() == OrderType.SALE && order.getOrderStatus() == OrderStatus.PAYMENT_SENT) {
+            // 배송 상태 수령 완료로 변경
+            delivery.updateDeliveryStatusAndTime(DeliveryStatus.RECEIVED);
+            // 주문 상태 수령 완료로 변경
+            order.updateOrderStatusAndTime(OrderStatus.RECEIVED);
+            // 주문한 상품 종류 찾기
+            Product product = order.getProduct();
+            // 해당 상품 재고 증가
+            product.increaseProductStock(order.getQuantity());
+            // 출력 메시지 수정
+            message = "수령 완료. 이용해주셔서 감사합니다.";
+            // 이외의 상황에서는 상태 변경 불가
+        } else {
+            throw new ConflictException(ErrorCode.DELIVERY_FAILED);
+        }
+        return message;
+    }
+}


### PR DESCRIPTION
## Issue
- #15 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/update_delivery_status -> dev

## 변경 사항
- 주문 상태가 결제 완료일 때, 배송 상태를 완료로 업데이트 할 수 있는 기능
- 아직 결제가 완료되지 않았거나 배송이 완료된 상태 혹은 배송 완료를 진행할 수 없는 상황이라면 409 상태 코드 출력
- 배송 상태 업데이트와 함께 주문 상태도 업데이트
- 주문 유형이 판매일 경우 상품의 재고 증가

## 테스트 결과

### Request
```java
HTTP : PATCH
URL: /api/deliveries/:deliveryId/complete
```

### Response : 성공시
`200 OK`
```
수령 완료. 이용해주셔서 감사합니다.
```

### Response : 실패시
- 잘못된 `deliveryId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "배송 정보를 찾을 수 없습니다."
}
```

- 결제 완료 전이거나 발송 또는 수령이 완료된 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "배송을 진행할 수 없습니다. 다시 시도해주세요."
}
```