### PR TITLE
[feat] 결제 정보 수정

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // 결제
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
     PAYMENT_FAILED(HttpStatus.CONFLICT, "결제를 진행할 수 없습니다. 다시 시도해주세요."),
+    PAYMENT_MODIFY_FAILED(HttpStatus.CONFLICT, "결제 정보를 수정할 수 없습니다. 다시 시도해주세요."),
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다. 다시 시도해주세요."),

--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
     PAYMENT_FAILED(HttpStatus.CONFLICT, "결제를 진행할 수 없습니다. 다시 시도해주세요."),
     PAYMENT_MODIFY_FAILED(HttpStatus.CONFLICT, "결제 정보를 수정할 수 없습니다. 다시 시도해주세요."),
+    INVALID_PAYMENT_INFORMATION(HttpStatus.BAD_REQUEST, "결제 정보를 수정할 수 없습니다. 입력한 정보를 다시 확인해주세요."),
 
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다. 다시 시도해주세요."),

--- a/src/main/java/com/wanted/gold/order/controller/PaymentController.java
+++ b/src/main/java/com/wanted/gold/order/controller/PaymentController.java
@@ -1,12 +1,10 @@
 package com.wanted.gold.order.controller;
 
+import com.wanted.gold.order.dto.ModifyPaymentRequestDto;
 import com.wanted.gold.order.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -18,6 +16,13 @@ public class PaymentController {
     @PatchMapping("/{paymentId}/complete")
     public ResponseEntity<String> completePayment(@PathVariable Long paymentId) {
         String response = paymentService.completePayment(paymentId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    // 결제 정보 수정
+    @PatchMapping("/{paymentId}")
+    public ResponseEntity<String> modifyPayment(@PathVariable Long paymentId, @RequestBody ModifyPaymentRequestDto requestDto) {
+        String response = paymentService.modifyPayment(paymentId, requestDto);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/wanted/gold/order/domain/Payment.java
+++ b/src/main/java/com/wanted/gold/order/domain/Payment.java
@@ -43,4 +43,10 @@ public class Payment {
         this.paymentAt = LocalDateTime.now();
         return this;
     }
+
+    public Payment modifyPayment(String bankName, String bankAccount) {
+        this.bankName = bankName;
+        this.bankAccount = bankAccount;
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/order/dto/ModifyPaymentRequestDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/ModifyPaymentRequestDto.java
@@ -1,0 +1,7 @@
+package com.wanted.gold.order.dto;
+
+public record ModifyPaymentRequestDto(
+        String bankName,
+        String bankAccount
+) {
+}

--- a/src/main/java/com/wanted/gold/order/service/PaymentService.java
+++ b/src/main/java/com/wanted/gold/order/service/PaymentService.java
@@ -1,5 +1,6 @@
 package com.wanted.gold.order.service;
 
+import com.wanted.gold.exception.BadRequestException;
 import com.wanted.gold.exception.ConflictException;
 import com.wanted.gold.exception.ErrorCode;
 import com.wanted.gold.exception.NotFoundException;
@@ -54,12 +55,15 @@ public class PaymentService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
         // 결제가 완료된 상태에서는 수정 불가
         if(payment.getPaymentStatus() != PaymentStatus.PENDING)
-            throw  new ConflictException(ErrorCode.PAYMENT_MODIFY_FAILED);
+            throw new ConflictException(ErrorCode.PAYMENT_MODIFY_FAILED);
+        // 은행 이름과 계좌번호 둘 다 빈값일 경우 수정 불가
+        if(requestDto.bankName().isBlank() && requestDto.bankAccount().isBlank())
+            throw new BadRequestException(ErrorCode.INVALID_PAYMENT_INFORMATION);
         payment.modifyPayment(
                 // 입력받은 은행 이름이 없을 경우 기존의 은행 이름
-                requestDto.bankName() != null ? requestDto.bankName() : payment.getBankName(),
+                !requestDto.bankName().isBlank() ? requestDto.bankName() : payment.getBankName(),
                 // 입력받은 계좌번호가 없을 경우 기존의 계좌번호
-                requestDto.bankAccount() != null ? requestDto.bankAccount() : payment.getBankAccount()
+                !requestDto.bankAccount().isBlank() ? requestDto.bankAccount() : payment.getBankAccount()
         );
         // 결제 정보 수정 성공 메시지 반환
         return "결제 정보 수정을 완료했습니다.";

--- a/src/main/java/com/wanted/gold/order/service/PaymentService.java
+++ b/src/main/java/com/wanted/gold/order/service/PaymentService.java
@@ -4,6 +4,7 @@ import com.wanted.gold.exception.ConflictException;
 import com.wanted.gold.exception.ErrorCode;
 import com.wanted.gold.exception.NotFoundException;
 import com.wanted.gold.order.domain.*;
+import com.wanted.gold.order.dto.ModifyPaymentRequestDto;
 import com.wanted.gold.order.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,5 +45,23 @@ public class PaymentService {
             throw new ConflictException(ErrorCode.PAYMENT_FAILED);
         }
         return message;
+    }
+
+    @Transactional
+    public String modifyPayment(Long paymentId, ModifyPaymentRequestDto requestDto) {
+        // 결제 식별번호로 payment 객체 찾기
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
+        // 결제가 완료된 상태에서는 수정 불가
+        if(payment.getPaymentStatus() != PaymentStatus.PENDING)
+            throw  new ConflictException(ErrorCode.PAYMENT_MODIFY_FAILED);
+        payment.modifyPayment(
+                // 입력받은 은행 이름이 없을 경우 기존의 은행 이름
+                requestDto.bankName() != null ? requestDto.bankName() : payment.getBankName(),
+                // 입력받은 계좌번호가 없을 경우 기존의 계좌번호
+                requestDto.bankAccount() != null ? requestDto.bankAccount() : payment.getBankAccount()
+        );
+        // 결제 정보 수정 성공 메시지 반환
+        return "결제 정보 수정을 완료했습니다.";
     }
 }


### PR DESCRIPTION
## Issue
- #19 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/modify_payment -> dev

## 변경 사항
- 수정할 은행 이름과 계좌 번호를 입력받아 결제 정보 수정
    - 은행 이름과 계좌 번호 둘 중 하나만 입력받아도 결제 정보 수정
- 이미 결제가 완료된 상태에서는 결제 정보 수정 불가
- 은행 이름과 계좌번호 둘 다 입력하지 않았을 때 400 상태 코드 출력

## 테스트 결과

### Request
```java
HTTP : PATCH
URL: /api/payments/:paymentId
```
- Request Body
```
{
    "bankName": "대방은행",
    "bankAccount": "222-33-444444"
}
```

### Response : 성공시
`200 OK`
```
결제 정보 수정을 완료했습니다.
```

### Response : 실패시
- 잘못된 `paymentId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "결제 정보를 찾을 수 없습니다."
}
```

- 이미 결제가 완료된 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "결제 정보를 수정할 수 없습니다. 다시 시도해주세요."
}
```

- 은행 이름과 계좌번호 둘 다 입력하지 않았을 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "결제 정보를 수정할 수 없습니다. 입력한 정보를 다시 확인해주세요."
}
```
