### PR TITLE
[feat] 배송 정보 수정

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     // 배송
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
     DELIVERY_FAILED(HttpStatus.CONFLICT, "배송을 진행할 수 없습니다. 다시 시도해주세요."),
+    DELIVERY_MODIFY_FAILED(HttpStatus.CONFLICT, "배송 정보를 수정할 수 없습니다. 다시 시도해주세요."),
+    INVALID_DELIVERY_INFORMATION(HttpStatus.BAD_REQUEST, "배송 정보를 수정할 수 없습니다. 입력한 정보를 다시 확인해주세요."),
 
     // 결제
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/wanted/gold/order/controller/DeliveryController.java
+++ b/src/main/java/com/wanted/gold/order/controller/DeliveryController.java
@@ -1,12 +1,10 @@
 package com.wanted.gold.order.controller;
 
+import com.wanted.gold.order.dto.ModifyDeliveryRequestDto;
 import com.wanted.gold.order.service.DeliveryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/deliveries")
@@ -18,6 +16,13 @@ public class DeliveryController {
     @PatchMapping("/{deliveryId}/complete")
     public ResponseEntity<String> completeDelivery(@PathVariable Long deliveryId) {
         String response = deliveryService.completeDelivery(deliveryId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    // 배송 정보 수정
+    @PatchMapping("/{deliveryId}")
+    public ResponseEntity<String> modifyDelivery(@PathVariable Long deliveryId, @RequestBody ModifyDeliveryRequestDto requestDto) {
+        String response = deliveryService.modifyDelivery(deliveryId, requestDto);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/wanted/gold/order/domain/Delivery.java
+++ b/src/main/java/com/wanted/gold/order/domain/Delivery.java
@@ -43,4 +43,11 @@ public class Delivery {
         this.deliveryAt = LocalDateTime.now();
         return this;
     }
+
+    public Delivery modifyDelivery(String address, String recipientName, String recipientPhone) {
+        this.address = address;
+        this.recipientName = recipientName;
+        this.recipientPhone = recipientPhone;
+        return this;
+    }
 }

--- a/src/main/java/com/wanted/gold/order/dto/ModifyDeliveryRequestDto.java
+++ b/src/main/java/com/wanted/gold/order/dto/ModifyDeliveryRequestDto.java
@@ -1,0 +1,8 @@
+package com.wanted.gold.order.dto;
+
+public record ModifyDeliveryRequestDto(
+        String address,
+        String recipientName,
+        String recipientPhone
+) {
+}


### PR DESCRIPTION
## Issue
- #21 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/lmodify_delivery -> dev

## 변경 사항
- 수정할 주소, 수령인 이름, 전화번호를 입력받아 배송 정보 수정
    - 어느 하나라도 입력받아도 배송 정보 수정
- 이미 배송이 완료된 상태에서는 배송 정보 수정 불가
- 주소, 수령인 이름, 전화번호 모두 입력하지 않았을 때 400 상태코드 출력

## 테스트 결과

### Request
```java
HTTP : PATCH
URL: /api/deliveries/:deliveryId
```
- Request Body
```
{
    "address": "서울시 동작구 노량진로",
    "recipientName": "이지삼",
    "recipientPhone": "01033334444"
}
```

### Response : 성공시
`200 OK`
```
배송 정보 수정을 완료했습니다.
```

### Response : 실패시
- 잘못된 `paymentId`를 입력했을 경우
`404 Not Found`
```
{
    "status": 404,
    "message": "배송 정보를 찾을 수 없습니다."
}
```

- 이미 배송이 완료된 경우
`409 Conflict`
```
{
    "status": 409,
    "message": "배송 정보를 수정할 수 없습니다. 다시 시도해주세요."
}
```

- 주소와 수령인 이름, 전화번호 모두 입력하지 않았을 경우
`400 Bad Request`
```
{
    "status": 400,
    "message": "배송 정보를 수정할 수 없습니다. 입력한 정보를 다시 확인해주세요."
}
```